### PR TITLE
Fix MCP OAuth flow on Cognito ESSENTIALS / Managed Login v2

### DIFF
--- a/src/main/java/com/entropyteam/entropay/users/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/entropyteam/entropay/users/auth/config/WebSecurityConfig.java
@@ -46,7 +46,8 @@ public class WebSecurityConfig {
     public static final String[] MCP_AUTH_GATEWAY_URLS = {
             "/.well-known/oauth-authorization-server",
             "/.well-known/openid-configuration",
-            "/oauth2/register"
+            "/oauth2/register",
+            "/mcp/oauth2/authorize"
     };
 
     private final CognitoOidcLogoutSuccessHandler cognitoOidcLogoutSuccessHandler;

--- a/src/main/java/com/entropyteam/entropay/users/auth/controllers/McpAuthorizationProxyController.java
+++ b/src/main/java/com/entropyteam/entropay/users/auth/controllers/McpAuthorizationProxyController.java
@@ -1,0 +1,54 @@
+package com.entropyteam.entropay.users.auth.controllers;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.entropyteam.entropay.users.auth.config.McpAuthGatewayProperties;
+
+/**
+ * Front-end for Cognito's {@code /oauth2/authorize} that strips the RFC 8707
+ * {@code resource} parameter before redirecting. Cognito user pools in the ESSENTIALS
+ * tier with Managed Login v2 accept {@code resource} on /authorize but the resulting
+ * authorization code then fails the /token exchange with {@code invalid_grant}. MCP
+ * clients (Claude custom connectors) follow MCP spec and always send {@code resource}
+ * for audience binding, so the only way to make the flow work end-to-end is to drop
+ * the parameter at the edge.
+ *
+ * <p>The {@code authorization_endpoint} advertised in our RFC 8414 metadata points at
+ * this controller instead of Cognito's domain directly, so the MCP client redirects here
+ * first and from here is forwarded to Cognito with a clean query string.
+ */
+@RestController
+public class McpAuthorizationProxyController {
+
+    private final McpAuthGatewayProperties properties;
+
+    public McpAuthorizationProxyController(McpAuthGatewayProperties properties) {
+        this.properties = properties;
+    }
+
+    @GetMapping("/mcp/oauth2/authorize")
+    public ResponseEntity<Void> proxyAuthorize(HttpServletRequest request) {
+        StringBuilder query = new StringBuilder();
+        for (Map.Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
+            if ("resource".equals(entry.getKey())) {
+                continue;
+            }
+            for (String value : entry.getValue()) {
+                if (!query.isEmpty()) {
+                    query.append('&');
+                }
+                query.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8))
+                        .append('=')
+                        .append(URLEncoder.encode(value, StandardCharsets.UTF_8));
+            }
+        }
+        String location = properties.cognitoDomain() + "/oauth2/authorize?" + query;
+        return ResponseEntity.status(302).header(HttpHeaders.LOCATION, location).build();
+    }
+}

--- a/src/main/java/com/entropyteam/entropay/users/auth/controllers/OAuthMetadataController.java
+++ b/src/main/java/com/entropyteam/entropay/users/auth/controllers/OAuthMetadataController.java
@@ -28,9 +28,11 @@ public class OAuthMetadataController {
     public ResponseEntity<AuthServerMetadataDto> authorizationServerMetadata() {
         String base = properties.publicBaseUrl();
         String cognitoDomain = properties.cognitoDomain();
+        // authorization_endpoint goes through our proxy (McpAuthorizationProxyController)
+        // which strips the RFC 8707 `resource` parameter — see that class for the why.
         AuthServerMetadataDto metadata = new AuthServerMetadataDto(
                 base,
-                cognitoDomain + "/oauth2/authorize",
+                base + "/mcp/oauth2/authorize",
                 cognitoDomain + "/oauth2/token",
                 base + "/oauth2/register",
                 properties.cognitoIssuer() + "/.well-known/jwks.json",

--- a/src/main/java/com/entropyteam/entropay/users/auth/services/DynamicClientRegistrationService.java
+++ b/src/main/java/com/entropyteam/entropay/users/auth/services/DynamicClientRegistrationService.java
@@ -15,6 +15,7 @@ import com.entropyteam.entropay.users.auth.dtos.ClientRegistrationRequestDto;
 import com.entropyteam.entropay.users.auth.dtos.ClientRegistrationResponseDto;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CognitoIdentityProviderException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.CreateManagedLoginBrandingRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CreateUserPoolClientRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CreateUserPoolClientResponse;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.DescribeUserPoolClientRequest;
@@ -94,11 +95,34 @@ public class DynamicClientRegistrationService {
             UserPoolClientType client = response.userPoolClient();
             LOGGER.info("Registered MCP OAuth client {} ({}) for redirect_uris {}",
                     client.clientId(), cognitoClientName, redirectUris);
+            applyDefaultManagedLoginBranding(client.clientId());
             return toResponse(client, cognitoClientName);
         } catch (CognitoIdentityProviderException e) {
             String detail = e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage();
             LOGGER.error("Cognito rejected client registration: {}", detail, e);
             throw new ClientRegistrationException("invalid_client_metadata", "Cognito error: " + detail);
+        }
+    }
+
+    /**
+     * Attaches a Cognito-provided default branding row to the freshly-created client.
+     * Required on user pools whose hosted UI domain runs Managed Login v2 (ESSENTIALS tier
+     * and above) — without a per-client branding the Cognito Hosted UI returns
+     * "Login pages unavailable" for every sign-in attempt. On LITE pools (Managed Login v1)
+     * the call is unnecessary; if AWS rejects it for that reason we log and move on so a
+     * single user-pool tier difference does not block registration.
+     */
+    private void applyDefaultManagedLoginBranding(String clientId) {
+        try {
+            cognitoClient.createManagedLoginBranding(CreateManagedLoginBrandingRequest.builder()
+                    .userPoolId(properties.userPoolId())
+                    .clientId(clientId)
+                    .useCognitoProvidedValues(true)
+                    .build());
+            LOGGER.info("Applied default ManagedLoginBranding to client {}", clientId);
+        } catch (CognitoIdentityProviderException e) {
+            String detail = e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage();
+            LOGGER.warn("Could not attach ManagedLoginBranding to client {} (continuing): {}", clientId, detail);
         }
     }
 

--- a/src/test/java/com/entropyteam/entropay/users/auth/controllers/OAuthMetadataControllerTest.java
+++ b/src/test/java/com/entropyteam/entropay/users/auth/controllers/OAuthMetadataControllerTest.java
@@ -29,8 +29,7 @@ class OAuthMetadataControllerTest {
         // Then
         assertEquals("http://localhost:8000", metadata.issuer());
         assertEquals("http://localhost:8000/oauth2/register", metadata.registrationEndpoint());
-        assertEquals("https://entropay-dev.auth.us-east-1.amazoncognito.com/oauth2/authorize",
-                metadata.authorizationEndpoint());
+        assertEquals("http://localhost:8000/mcp/oauth2/authorize", metadata.authorizationEndpoint());
         assertEquals("https://entropay-dev.auth.us-east-1.amazoncognito.com/oauth2/token",
                 metadata.tokenEndpoint());
         assertTrue(metadata.codeChallengeMethodsSupported().contains("S256"));


### PR DESCRIPTION
## Summary

Fixes the MCP custom-connector login flow against the **prod** Cognito user pool, which runs ESSENTIALS tier with Managed Login v2. Both bugs only manifest there; dev (LITE/MLv1) was unaffected, which is why neither was caught when the gateway shipped.

- **Bug 1 — DCR clients have no Managed Login Branding.** MLv2 requires a per-client `ManagedLoginBranding` row; without one the hosted UI returns *"Login pages unavailable"* on every sign-in. `DynamicClientRegistrationService` now calls `CreateManagedLoginBranding(useCognitoProvidedValues=true)` right after `CreateUserPoolClient`. The call is wrapped so a LITE pool that rejects it does not break registration.
- **Bug 2 — Cognito MLv2 corrupts codes when `/authorize` carries the RFC 8707 `resource` parameter.** Cognito accepts the parameter and emits a code that always fails the subsequent token exchange with `invalid_grant`. MCP clients always send `resource` (audience binding per spec). New `McpAuthorizationProxyController` exposes `GET /mcp/oauth2/authorize`, strips the `resource` param, and 302-redirects to Cognito. `OAuthMetadataController` now advertises this proxy as the `authorization_endpoint`. Token and userinfo endpoints are unchanged.

Both root causes were nailed down with a local MITM against Cognito prod and a manual PKCE flow — `resource` present → `invalid_grant`, `resource` removed → `200 OK` with tokens.

## IAM dependency

The DCR service needs `cognito-idp:CreateManagedLoginBranding` on the user pool. The prod policy `EntropayMcpDcrCognitoPolicy` was already updated (v3). Dev still needs the same addition before this merges and deploys.

## Test plan

- [x] Local boot of `users-auth` with the patched code and `application-e2e-prod` (uses prod Cognito via devtunnel) — end-to-end via Claude custom connector returns tokens and lists MCP tools.
- [x] Manual PKCE flow confirms `resource`-bearing code → `invalid_grant`, `resource`-stripped → `200 OK`.
- [ ] CI build green.
- [ ] After merge + deploy to dev, smoke test Claude → dev MCP server (should be a no-op regression — dev wasn't broken, just verifying the branding+proxy don't break LITE).
- [ ] After tagging prod release, smoke test Claude → prod MCP server (this is the actual user-visible fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)